### PR TITLE
Correct lazy-loading not firing

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1451,49 +1451,51 @@
 
     };
 
-    Slick.prototype.lazyLoad = function() {
+     Slick.prototype.lazyLoad = function() {
 
         var _ = this,
             loadRange, cloneRange, rangeStart, rangeEnd;
 
-        function loadImages(imagesScope) {
-
-            $('img[data-lazy]', imagesScope).each(function() {
-
-                var image = $(this),
-                    imageSource = $(this).attr('data-lazy'),
-                    imageToLoad = document.createElement('img');
-
-                imageToLoad.onload = function() {
-
-                    image
-                        .animate({ opacity: 0 }, 100, function() {
-                            image
-                                .attr('src', imageSource)
-                                .animate({ opacity: 1 }, 200, function() {
-                                    image
+          function loadImages(imagesScope) {
+               setTimeout(function() {
+                    $('img[data-lazy]', imagesScope).each(function() {
+                    
+                         var image = $(this),
+                         imageSource = $(this).attr('data-lazy'),
+                         imageToLoad = document.createElement('img');
+                         
+                         imageToLoad.onload = function() {
+                         
+                              image
+                              .animate({ opacity: 0 }, 100, function() {
+                                   image
+                                   .attr('src', imageSource)
+                                   .animate({ opacity: 1 }, 200, function() {
+                                        image
                                         .removeAttr('data-lazy')
                                         .removeClass('slick-loading');
-                                });
-                            _.$slider.trigger('lazyLoaded', [_, image, imageSource]);
-                        });
-
-                };
-
-                imageToLoad.onerror = function() {
-
-                    image
-                        .removeAttr( 'data-lazy' )
-                        .removeClass( 'slick-loading' )
-                        .addClass( 'slick-lazyload-error' );
-
-                    _.$slider.trigger('lazyLoadError', [ _, image, imageSource ]);
-
-                };
-
-                imageToLoad.src = imageSource;
-
-            });
+                                   });
+                                   _.$slider.trigger('lazyLoaded', [_, image, imageSource]);
+                              });
+                         
+                         };
+                         
+                         imageToLoad.onerror = function() {
+                         
+                              image
+                              .removeAttr( 'data-lazy' )
+                              .removeClass( 'slick-loading' )
+                              .addClass( 'slick-lazyload-error' );
+                              
+                              _.$slider.trigger('lazyLoadError', [ _, image, imageSource ]);
+                         
+                         };
+                         
+                         imageToLoad.src = imageSource;
+                    
+                    });
+               
+               }, 0)
 
         }
 


### PR DESCRIPTION
Upon carousel initialization, with lazy-loading set to on demand, the images do not load until we move the carousel. I wrapped the call to the loading of the images in a timeout and the images load correctly now.
